### PR TITLE
Do not check VBoxManage on app start and add hyper-v provider.

### DIFF
--- a/Lanayo.VagrantManager/App.cs
+++ b/Lanayo.VagrantManager/App.cs
@@ -71,8 +71,6 @@ namespace Lanayo.Vagrant_Manager {
 
             var dummy = _NativeMenu.Menu.Handle; // forces handle creation so _NativeMenu.Menu.BeginInvoke can work before the menu was ever clicked
 
-            this.VerifyVBoxManagePath();
-
             this.RefreshVagrantMachines();
 
             this.RefreshTimerState();

--- a/Lanayo.VagrantManager/Core/Vagrant/VagrantManager.cs
+++ b/Lanayo.VagrantManager/Core/Vagrant/VagrantManager.cs
@@ -174,7 +174,7 @@ namespace Lanayo.Vagrant_Manager.Core.Vagrant {
         }
 
         public string[] GetProviderIdentifiers() {
-            return _Providers.Keys.ToArray().Concat(new List<string> { "vmware_workstation", "vmware_fusion", "docker" }).ToArray();
+            return _Providers.Keys.ToArray().Concat(new List<string> { "hyperv", "vmware_workstation", "vmware_fusion", "docker" }).ToArray();
         }
 
     }


### PR DESCRIPTION
I'm new to Windows development, but took a stab at adding hyperv provider, it works. This also removes the VBoxManage check.

Given the various providers supported, could the verification be done when we click the up/down? What's your thought process? 